### PR TITLE
Semantic Range with Context Bounds and Extension Methods

### DIFF
--- a/documents/case-study/general-semantic-range-class/readme.md
+++ b/documents/case-study/general-semantic-range-class/readme.md
@@ -70,6 +70,26 @@ And anyone reading this code can immediately understand what our cases mean:
 
 https://github.com/michaelahlers/scala-guide/blob/2a79184aa0d109637efae50063a9819862e2b2c6/src/test/scala/caseStudy/genericSemanticRangeClass/version1/RangeSpec.scala#L14-L34
 
+### Second Version
+
+If you're satisfied with the previous version, this might be superfluous. It's a bonus round for anyone wanting to explore a few more features of the Scala language.
+
+Consider how context bounds and [extension methods][glossary-extension-methods] can make our `Range` type safer and easier to use.
+
+In what way is it safer? Consider the `Bounded` type. It _could_ represent an exclusionary range where `left` is greater than `right`, but let's skip theory for a moment and impose a hard constraint:
+
+https://github.com/michaelahlers/scala-guide/blob/557b25d10a16b7a5a7b1dbd0d1e850b5fbe043bd/src/main/scala/caseStudy/genericSemanticRangeClass/version2/Range.scala#L22-L30
+
+Note how we've imposed a context bound of `Ordering` on `A`, which means we _must_ have an implicit `Ordering` in scope to construct an instance. We don't need to introduce a symbol (the context bound notation essentially makes the implicit value anonymous) for that `Ordering` since it's used by the `<=`, provided by an implicit infix operator given to us by the language.
+
+If we attempt to construct an invalid `Bounded`, an `IllegalArgumentException` will be thrown. Before you point out how this violates my incessant claims we avoid throwing exceptions, this example also provides a factory function that captures errors as values:
+
+https://github.com/michaelahlers/scala-guide/blob/557b25d10a16b7a5a7b1dbd0d1e850b5fbe043bd/src/main/scala/caseStudy/genericSemanticRangeClass/version2/Range.scala#L34-L45
+
+And our tests bear that out:
+
+https://github.com/michaelahlers/scala-guide/blob/557b25d10a16b7a5a7b1dbd0d1e850b5fbe043bd/src/test/scala/caseStudy/genericSemanticRangeClass/version2/RangeSpec.scala#L50-L58
+
 ## See also
 
 - [Case Study: Better Interface Design with Types][case-study-better-interface-design-with-types]

--- a/src/main/scala/caseStudy/genericSemanticRangeClass/version2/Range.scala
+++ b/src/main/scala/caseStudy/genericSemanticRangeClass/version2/Range.scala
@@ -1,0 +1,49 @@
+package caseStudy.genericSemanticRangeClass.version2
+
+import org.scalactic.Bad
+import org.scalactic.ErrorMessage
+import org.scalactic.Good
+import org.scalactic.Or
+import org.scalactic.Requirements.require
+import scala.math.Ordering.Implicits.infixOrderingOps
+import scala.util.control.NonFatal
+
+sealed trait Range[A]
+object Range {
+
+  case class LeftBounded[A](
+    minimum: A,
+  ) extends Range[A]
+
+  case class RightBounded[A](
+    maximum: A,
+  ) extends Range[A]
+
+  /**
+   * @throws [[IllegalArgumentException]] if [[minimum]] is greater than [[maximum]].
+   */
+  case class Bounded[A: Ordering](
+    minimum: A,
+    maximum: A,
+  ) extends Range[A] {
+    require(minimum <= maximum)
+  }
+
+  object Bounded {
+
+    /**
+     * @return A [[Good]] [[Bounded]] valid; otherwise, a [[Bad]].
+     */
+    def of[A: Ordering](
+      minimum: A,
+      maximum: A,
+    ): Bounded[A] Or ErrorMessage =
+      try Good(Bounded(minimum, maximum))
+      catch {
+        case NonFatal(cause) =>
+          Bad(cause.getMessage)
+      }
+
+  }
+
+}

--- a/src/main/scala/caseStudy/genericSemanticRangeClass/version2/syntax.scala
+++ b/src/main/scala/caseStudy/genericSemanticRangeClass/version2/syntax.scala
@@ -1,0 +1,24 @@
+package caseStudy.genericSemanticRangeClass.version2
+
+import caseStudy.genericSemanticRangeClass.version2.Range.Bounded
+import caseStudy.genericSemanticRangeClass.version2.Range.LeftBounded
+import caseStudy.genericSemanticRangeClass.version2.Range.RightBounded
+import org.scalactic.ErrorMessage
+import org.scalactic.Or
+
+object syntax {
+
+  implicit class RangeValueOps[A](private val self: A) extends AnyVal {
+
+    def leftBounded: LeftBounded[A] =
+      LeftBounded(self)
+
+    def rightBounded: RightBounded[A] =
+      RightBounded(self)
+
+    def bounded(by: A)(implicit A: Ordering[A]): Bounded[A] Or ErrorMessage =
+      Bounded.of(self, by)
+
+  }
+
+}

--- a/src/test/scala/caseStudy/genericSemanticRangeClass/version2/RangeSpec.scala
+++ b/src/test/scala/caseStudy/genericSemanticRangeClass/version2/RangeSpec.scala
@@ -1,0 +1,100 @@
+package caseStudy.genericSemanticRangeClass.version2
+
+import caseStudy.genericSemanticRangeClass.version2.Range.Bounded
+import caseStudy.genericSemanticRangeClass.version2.Range.LeftBounded
+import caseStudy.genericSemanticRangeClass.version2.Range.RightBounded
+import caseStudy.genericSemanticRangeClass.version2.syntax._
+import java.time.LocalDate
+import org.scalactic.Bad
+import org.scalactic.Good
+import org.scalatest.Inside._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class RangeSpec extends AnyFlatSpec {
+  import RangeSpec.orderingLocalDate
+  import RangeSpec.samples
+
+  it should "represent left-bounded ranges" in {
+    inside(samples.leftBounded) {
+      case LeftBounded(minimum) =>
+        minimum shouldBe samples.today
+    }
+  }
+
+  it should "represent right-bounded ranges" in {
+    inside(samples.rightBounded) {
+      case RightBounded(right) =>
+        right shouldBe samples.nextWeek
+    }
+  }
+
+  it should "represent bounded ranges" in {
+    inside(samples.bounded) {
+      case Bounded(minimum, maximum) =>
+        minimum shouldBe samples.today
+        maximum shouldBe samples.nextWeek
+    }
+  }
+
+  it should "not bound unordered types" in {
+
+    /** Phantom type; it doesn't matter what this is so long as it doesn't have an [[Ordering]]. */
+    trait Value
+    def left: Value = ???
+    def right: Value = ???
+
+    """Bounded(left, right)""" shouldNot compile
+  }
+
+  it should "not permit mismatched minimum and maximum bounds" in {
+    an[IllegalArgumentException] shouldBe thrownBy {
+      Bounded(samples.nextWeek, samples.today)
+    }
+  }
+
+  it should "report bounding error as value" in {
+    Bounded.of(samples.nextWeek, samples.today) shouldBe a[Bad[_]]
+  }
+
+  it should "provide syntax for constructing ranges" in {
+    inside(samples.today.leftBounded) {
+      case LeftBounded(minimum) =>
+        minimum shouldBe samples.today
+    }
+
+    inside(samples.nextWeek.rightBounded) {
+      case RightBounded(maximum) =>
+        maximum shouldBe samples.nextWeek
+    }
+
+    inside(samples.today.bounded(samples.nextWeek)) {
+      case Good(Bounded(minimum, maximum)) =>
+        minimum shouldBe samples.today
+        maximum shouldBe samples.nextWeek
+    }
+  }
+
+}
+
+object RangeSpec {
+
+  object samples {
+
+    val today: LocalDate = LocalDate.now()
+    val nextWeek: LocalDate = today.plusDays(7)
+
+    val leftBounded: Range[LocalDate] = LeftBounded(today)
+    val rightBounded: Range[LocalDate] = RightBounded(nextWeek)
+    val bounded: Range[LocalDate] = Bounded(today, nextWeek)
+
+  }
+
+  /**
+   * Scala doesn't provide an [[Ordering]] of [[LocalDate]] out-of-the-box. Luckily, it's trivial to make one since [[LocalDate]] is a [[java.lang.Comparable]].
+   */
+  implicit val orderingLocalDate: Ordering[LocalDate] = { (x: LocalDate, y: LocalDate) =>
+    x.compareTo(y)
+  }
+
+}


### PR DESCRIPTION
Followup on https://github.com/michaelahlers/scala-guide/pull/7 with constraints imposed on the `Range` with context bounds and useful syntax by extension methods.